### PR TITLE
Fix brew install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Other issues can be submitted via [Issues](https://github.com/keybase/keybase-is
 
 On OSX, the supported way to build from source is to use `brew`:
 
-    brew --build-from-source keybase/beta/kbstage
+    brew install --build-from-source keybase/beta/kbstage
 
 On Linux, to build directly from this repo, use `./build.sh`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Other issues can be submitted via [Issues](https://github.com/keybase/keybase-is
 
 On OSX, the supported way to build from source is to use `brew`:
 
+    brew install go
     brew install --build-from-source keybase/beta/kbstage
 
 On Linux, to build directly from this repo, use `./build.sh`.


### PR DESCRIPTION
The existing docs have two issues.

* 'install' was missing from the brew build command.
* If the user doesn't already have Go installed, the --build-from-source command causes Go to be built from source as well. Which is slow and unnecessary. 